### PR TITLE
PR for #2 default command callback

### DIFF
--- a/src/emulator/command-runner.js
+++ b/src/emulator/command-runner.js
@@ -27,13 +27,14 @@ const makeRunnerErrorOutput = (errorType) => {
  * @param  {Map}    commandMapping command mapping from emulator state
  * @param  {string} commandName    name of command to run
  * @param  {array}  commandArgs    commands to provide to the command function
+ * @param  {function}  notFoundCallback a default function to be run if no command is found
  * @return {object}                outputs and/or new state of the emulator
  */
-export const run = (commandMapping, commandName, commandArgs) => {
+export const run = (commandMapping, commandName, commandArgs, notFoundCallback = () => ({
+  output: makeRunnerErrorOutput(emulatorErrorType.COMMAND_NOT_FOUND)
+})) => {
   if (!CommandMappingUtil.isCommandSet(commandMapping, commandName)) {
-    return {
-      output: makeRunnerErrorOutput(emulatorErrorType.COMMAND_NOT_FOUND)
-    };
+    return notFoundCallback();
   }
 
   const command = CommandMappingUtil.getCommandFn(commandMapping, commandName);

--- a/src/emulator/command-runner.js
+++ b/src/emulator/command-runner.js
@@ -34,7 +34,7 @@ export const run = (commandMapping, commandName, commandArgs, notFoundCallback =
   output: makeRunnerErrorOutput(emulatorErrorType.COMMAND_NOT_FOUND)
 })) => {
   if (!CommandMappingUtil.isCommandSet(commandMapping, commandName)) {
-    return notFoundCallback();
+    return notFoundCallback(...commandArgs);
   }
 
   const command = CommandMappingUtil.getCommandFn(commandMapping, commandName);

--- a/test/emulator/command-runner.spec.js
+++ b/test/emulator/command-runner.spec.js
@@ -56,5 +56,13 @@ describe('command-runner', () => {
 
       chai.expect(output.content).to.include(emulatorErrorType.COMMAND_NOT_FOUND);
     });
+
+    it('should run a notFoundCallback command if command not in mapping and notFoundCallback provided', () => {
+      const commandMapping = createCommandMapping({});
+      const notFoundCallback = ()=> true;
+
+      chai.expect(run(commandMapping, 'noSuchKey', [], notFoundCallback)).to.equal(true);
+    });
+
   });
 });


### PR DESCRIPTION
Allows a default command to be passed in as a callback in the CommandRunner.run function
```js
 * @param  {Map}    commandMapping command mapping from emulator state
 * @param  {string} commandName    name of command to run
 * @param  {array}  commandArgs    commands to provide to the command function
 * @param  {function}  notFoundCallback a default function to be run if no command is found
 * @return {object}                outputs and/or new state of the emulator
```

All tests pass
452 passing (368ms)