### PR TITLE
Gracefully handle the case when command function does not return object

### DIFF
--- a/src/emulator/index.js
+++ b/src/emulator/index.js
@@ -107,7 +107,7 @@ export default class Emulator {
 
       const {state: nextState, output, outputs} = CommandRunner.run(
         commandMapping, commandName, commandArgs, errorStr
-      );
+      ) || {};
 
       if (nextState) {
         state = nextState;


### PR DESCRIPTION
Currently if the `function` of a command does not return an object, error is thrown because the code tries to destructure `undefined`. However, it is possible that a command does not have an output or change in state - if it only contains side-effects not related to the terminal state. This PR just handles this case.